### PR TITLE
tell dataservice nacos name to adservice

### DIFF
--- a/charts/opentelemetry-demo-lite/templates/_help.tpl
+++ b/charts/opentelemetry-demo-lite/templates/_help.tpl
@@ -107,6 +107,8 @@ common java adservice opt bug
 {{/* check nacos is enable */}}
 {{- if .Values.global.microservices.nacos.enabled }}
 {{- $opt = cat $opt "-Dspring.dataService.enabled=true" -}}
+{{- $opt = cat $opt "-Ddata_service_name=webstore-demo-dataservice:8080" -}}
+
 {{- else }}
 {{- $opt = cat $opt "-Dspring.dataService.enabled=false" -}}
 {{- end }}


### PR DESCRIPTION
WHY： when adservice connects with dataservice, it should tell adservice the nacos-registered name  of downstream dataservice

否则 当开启dataservice时，adservice拿不到任何数据


担忧： 不知道插在这个位置合适不合适